### PR TITLE
Ryver #HELP-634: Ensure custom contact tokens are evaluated

### DIFF
--- a/api/v3/Email/Send.php
+++ b/api/v3/Email/Send.php
@@ -162,7 +162,7 @@ function civicrm_api3_email_send($params) {
     }
 
     // Change the contact array to the format the hook expects.
-    $contactHookArray[$contact['contact_id']] = $contact;
+    $contactHookArray = CRM_Utils_Token::getTokenDetails([$contact['contact_id']])[0];
     CRM_Utils_Hook::tokenValues($contactHookArray, array_keys($contactHookArray), NULL, $tokens);
     // Now update the original array.
     $contact = $contactHookArray[$contact['contact_id']];


### PR DESCRIPTION
Ryver #HELP-634.  It appears that the Email API is unable to process custom contact tokens because it never evaluates them.  This PR addresses this issue.  This has been tested and appears to be working on my local dev environment, however I'd like to do further testing on Dev prior to merging.